### PR TITLE
cache busting with git digest

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -8,16 +8,28 @@
  * @todo Detect if there's already a query string
  */
 
- 'use strict';
+'use strict';
 
- var $ = require('cheerio'),
- MD5 = require('MD5');
+var $ = require('cheerio'),
+MD5 = require('MD5'),
+exec = require('sync-exec');
 
- exports.busted = function(fileContents, options) {
+exports.busted = function(fileContents, options) {
   var self = this;
 
   if (options.type === 'timestamp') {
     self.timestamp = new Date().getTime();
+  }
+
+  if (options.type === 'git-digest') {
+    var execOutput = exec('git rev-parse --short HEAD');
+    if (execOutput.stderr) {
+      throw execOutput.stderr;
+    } else {
+      self.gitDigest = execOutput.stdout;
+      //remove '\n'
+      self.gitDigest = self.gitDigest.substr(0, self.gitDigest.length - 1);
+    }
   }
 
   var protocolRegEx = /^http(s)?/,
@@ -28,29 +40,33 @@
   for (var i = 0; i < $styles.length; i++) {
     var styleHref = $styles[i].attribs.href;
 
-      // Test for http(s) and don't cache bust if (assumed) served from CDN
-      if (!protocolRegEx.test(styleHref)) {
-        if (options.type === 'timestamp') {
-          fileContents = fileContents.replace(styleHref, styleHref + '?t=' + self.timestamp);
-        } else {
-          fileContents = fileContents.replace(styleHref, styleHref + '?hash=' + MD5(fileContents));
-        }
+    // Test for http(s) and don't cache bust if (assumed) served from CDN
+    if (!protocolRegEx.test(styleHref)) {
+      if (options.type === 'timestamp') {
+        fileContents = fileContents.replace(styleHref, styleHref + '?t=' + self.timestamp);
+      } else if (options.type === 'git-digest') {
+        fileContents = fileContents.replace(styleHref, styleHref + '?v=' + self.gitDigest);
+      } else {
+        fileContents = fileContents.replace(styleHref, styleHref + '?hash=' + MD5(fileContents));
       }
     }
+  }
 
-    // Loop the script srcs
-    for (var j = 0; j < $scripts.length; j++) {
-      var scriptSrc = $scripts[j].attribs.src;
+  // Loop the script srcs
+  for (var j = 0; j < $scripts.length; j++) {
+    var scriptSrc = $scripts[j].attribs.src;
 
-      // Test for http(s) and don't cache bust if (assumed) served from CDN
-      if (!protocolRegEx.test(scriptSrc)) {
-        if (options.type === 'timestamp') {
-          fileContents = fileContents.replace(scriptSrc, scriptSrc + '?t=' + self.timestamp);
-        } else {
-          fileContents = fileContents.replace(scriptSrc, scriptSrc + '?hash=' + MD5(fileContents));
-        }
+    // Test for http(s) and don't cache bust if (assumed) served from CDN
+    if (!protocolRegEx.test(scriptSrc)) {
+      if (options.type === 'timestamp') {
+        fileContents = fileContents.replace(scriptSrc, scriptSrc + '?t=' + self.timestamp);
+      } else if (options.type === 'git-digest') {
+        fileContents = fileContents.replace(scriptSrc, scriptSrc + '?v=' + self.gitDigest);
+      } else {
+        fileContents = fileContents.replace(scriptSrc, scriptSrc + '?hash=' + MD5(fileContents));
       }
     }
+  }
 
-    return fileContents;
-  };
+  return fileContents;
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-mocha-cli": "~1.10.0",
     "jshint-stylish": "~1.0.0",
     "load-grunt-tasks": "~1.0.0",
+    "sync-exec": "~0.5.0",
     "time-grunt": "~1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
tested manually.

In my use case, I need cache busting with git digest. with `timestamp` option, some html files containing the same stylesheets or scripts will have different timestamps. For example, a.html and b.html contains the same c.css, after cache busting, a.html contains c.css?t=1437286993 and b.html contains c.css?t=1437287000. Browser will download same file twice, which I want to avoid.
