### PR TITLE
Added support for custom web-components (As used by Polymer)

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -24,6 +24,23 @@
   $scripts = $(fileContents).find('script'),
   $styles = $(fileContents).find('link[rel=stylesheet]');
 
+  /* Cache busting webcomponent custom elements */
+  var elements = $(fileContents).find('link[rel=import]');
+
+  // Loop the elements hrefs
+  for (var i = 0; i < elements.length; i++) {
+    var elementsHref = elements[i].attribs.href;
+
+      // Test for http(s) and don't cache bust if (assumed) served from CDN
+      if (!protocolRegEx.test(elementsHref)) {
+        if (options.type === 'timestamp') {
+          fileContents = fileContents.replace(elementsHref, elementsHref + '?t=' + timestamp);
+        } else {
+          fileContents = fileContents.replace(elementsHref, elementsHref + '?hash=' + MD5(fileContents));
+        }
+      }
+    }
+
   // Loop the stylesheet hrefs
   for (var i = 0; i < $styles.length; i++) {
     var styleHref = $styles[i].attribs.href;


### PR DESCRIPTION
Added "rel=import" loop for elements.

Background of change:
Libraries such as Google's Polymer uses webcomponents to create custom elements. Those custom elements are imported with links containing the attribute "rel=import".
