### PR TITLE
fix(cachebust.js): do not consider script tags without src

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -46,6 +46,11 @@ exports.busted = function(fileContents, options) {
 
   // Loop the script srcs
   for (var j = 0; j < scripts.length; j++) {
+    //Do not consider script tag without src attribute : <script>...</script>
+    if(scripts[j].attribs.src === undefined){ 
+      continue;
+    }
+
     var origSrc =  scripts[j].attribs.src,
       scriptSrc = scripts[j].attribs.src.split("?")[0];
 


### PR DESCRIPTION
:black_small_square: Before: if base file contains <script>[code here]</script> the cachebust.js failed at line 50 "scripts[j].attribs.src.split("?")[0];" because src is undefined
:black_small_square: Issue: if base file required to contain javascript (without import from another file), cachebust failed...
:black_small_square: Now: if base file contains <script>[code here]</script> cachebust will not failed anymore and will just ignore it

https://github.com/furzeface/cachebust/issues/6
