### PR TITLE
Fix md5 case-sensitivity issue

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -10,7 +10,7 @@
 'use strict';
 
 var cheerio = require('cheerio'),
-  MD5 = require('MD5'),
+  MD5 = require('md5'),
   fs = require('fs');
 
 function loadAttribute(content) {


### PR DESCRIPTION
Change requires('MD5') to requires('md5') so that cachebust works on non Windows machines where file names are case-sensitive
