### PR TITLE
Fix no protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Project meta
 *.sublime-workspace
+.idea
 
 # Don't commit dependencies!
 node_modules

--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -48,7 +48,7 @@ exports.busted = function(fileContents, options) {
     currentTimestamp : new Date().getTime()
   };
 
-  var protocolRegEx = /^http(s)?/, elements = $('script[src], link[rel=stylesheet][href]');
+  var protocolRegEx = /^(http(s)?)|\/\//, elements = $('script[src], link[rel=stylesheet][href]');
 
   for (var i = 0, len = elements.length; i < len; i++) {
     var originalAttrValue = loadAttribute(elements[i]);

--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -53,7 +53,7 @@ exports.busted = function(fileContents, options) {
   for (var i = 0, len = elements.length; i < len; i++) {
     var originalAttrValue = loadAttribute(elements[i]);
 
-    // Test for http(s) and don't cache bust if (assumed) served from CDN
+    // Test for http(s) and // and don't cache bust if (assumed) served from CDN
     if (!protocolRegEx.test(originalAttrValue)) {
       fileContents = self[options.type](fileContents, originalAttrValue, options);
     }

--- a/test/fixtures/default_options.html
+++ b/test/fixtures/default_options.html
@@ -14,6 +14,7 @@
   </script>
   <script src="scripts/moar.js"></script>
   <script src="http://best-cdn-ever.com/scripts/evenMoar.js"></script>
+  <script src="//best-cdn-ever.com/scripts/anotherOne.js"></script>
   <script src="scripts/baz.js?v=3432243241413243143124132"</script>
 </body>
 </html>


### PR DESCRIPTION
Currently when trying to cache bust files that include assets with no protocol (e.g. ```//code.jquery.com/jquery-3.1.1.min.js```), it will actually try to cache bust it instead of ignoring it. Just did a quick change to the RegEx to also match ```//```. Thanks.