### PR TITLE
Fix it for there is no file in the local file system

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -60,7 +60,8 @@ exports.busted = function(fileContents, options) {
     var originalAttrValue = loadAttribute(elements[i]);
 
     // Test for http(s) and // and don't cache bust if (assumed) served from CDN
-    if (!protocolRegEx.test(originalAttrValue)) {
+    // Test for file exist in local filesytem
+    if (!protocolRegEx.test(originalAttrValue) && fs.existsSync(options.basePath + originalAttrValue.split("?")[0])) {
       fileContents = self[options.type](fileContents, originalAttrValue, options);
     }
   }


### PR DESCRIPTION
Fix it because there is no file in the local file system and you want to use MD5 hash.
An example would be to use the SignalR, it creates a route / signalr / hubs, but this route is just virtual. There is no such script in the project directory.