### PR TITLE
Bypass missing files when using MD5

### DIFF
--- a/lib/cachebust.js
+++ b/lib/cachebust.js
@@ -32,8 +32,13 @@ exports.busted = function(fileContents, options) {
 
   self.MD5 = function(fileContents, originalAttrValue, options) {
     var originalAttrValueWithoutCacheBusting = originalAttrValue.split("?")[0],
-        hash = MD5(fs.readFileSync(options.basePath + originalAttrValueWithoutCacheBusting).toString());
+        filePath = options.basePath + originalAttrValueWithoutCacheBusting;
 
+    if (!fs.existsSync(filePath)) {
+      return fileContents;
+    }
+
+    var hash = MD5(fs.readFileSync(filePath).toString());
     return fileContents.replace(originalAttrValue, originalAttrValueWithoutCacheBusting + '?v=' + hash);
   };
 

--- a/test/fixtures/default_options.html
+++ b/test/fixtures/default_options.html
@@ -17,5 +17,6 @@
   <script src="http://best-cdn-ever.com/scripts/evenMoar.js"></script>
   <script src="//best-cdn-ever.com/scripts/anotherOne.js"></script>
   <script src="scripts/baz.js?v=3432243241413243143124132"</script>
+  <script src="scripts/missing.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When using MD5, the referenced assets obviously need to exist to be able to compute the hash.
A missing asset causes a ENOENT error.

In some cases, a missing asset could be normal. My use case is a Ionic (Cordova) application, where the `cordova.js` script is available only in packaged applications, but not for the web.

This patch bypasses replacements for missing local assets.