### PR TITLE
Upgrade npm package 'cheerio' to v0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "md5": "^2.0.0",
-    "cheerio": "^0.19.0"
+    "cheerio": "^0.22.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.10.0",


### PR DESCRIPTION
Upgraded `cheerio` to version v.0.22.0 to fix `lodash`'s `Prototype Pollution` vunerability.

![Screenshot 2019-06-07 at 4 57 41 PM](https://user-images.githubusercontent.com/472783/59118806-0b7efb80-8949-11e9-8a96-ef22f245af72.png)
